### PR TITLE
お気に入りボタンUIを実装

### DIFF
--- a/CTAProject/UIComponent/View/ShopTableViewCell.swift
+++ b/CTAProject/UIComponent/View/ShopTableViewCell.swift
@@ -43,6 +43,12 @@ final class ShopTableViewCell: UITableViewCell {
         return label
     }()
 
+    private let favoriteButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setImage(UIImage(systemName: "star"), for: .normal)
+        button.tintColor = .systemGray
+        return button
+    }()
     // MARK: - Lifecycle
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -54,21 +60,31 @@ final class ShopTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        addSubview(favoriteButton)
+    }
+
     // MARK: - Helpers
 
     private func configureUI() {
         shopImageView.setDimensions(height: 80, width: 80)
         addSubview(shopImageView)
-        shopImageView.centerY(inView: self, leftAnchor: self.leftAnchor, paddingLeft: 20)
+        shopImageView.centerY(inView: self, leftAnchor: leftAnchor, paddingLeft: 20)
 
         let stack = UIStackView(arrangedSubviews: [shopNameLabel, budgetLabel, shopDetailLabel])
         stack.spacing = 8
         stack.distribution = .fill
         stack.axis = .vertical
 
+        favoriteButton.setDimensions(height: 40, width: 40)
+        addSubview(favoriteButton)
+        favoriteButton.centerY(inView: self)
+        favoriteButton.anchor(right: rightAnchor, paddingRight: 20)
+
         addSubview(stack)
         stack.centerY(inView: self)
-        stack.anchor(left: shopImageView.rightAnchor, right: self.rightAnchor, paddingLeft: 20, paddingRight: 20)
+        stack.anchor(left: shopImageView.rightAnchor, right: favoriteButton.leftAnchor, paddingLeft: 20, paddingRight: 12)
     }
 
     func setupData(item: Shop) {


### PR DESCRIPTION
## 関連URL

[タスク2](https://github.com/sosuiiii/CTAProject2022/issues/3)に関する実装

## 前提

・一旦UIの実装のみを切り分けてPR出します
・次のPRでお気に入り追加削除の実装を行いたいと思います

## 仕様

・コードベースでのUI実装
・RxSwiftを使ったコーディング

## 対応内容

- [x] お気に入りボタンのUI実装
- [x] お気に入りボタンタップ検知→UI更新の実装
 
### 実装機能1

0e0c81a4eeae4ad6e00b1919609807749b57cfc4: UIの実装
dd91cc61d70831ca033486c12c3cf3ab56be70a5: タップイベントの実装

## レビュー観点

・Rxが適切に使えているか
・toggleを再現するためにscanオペレータを使っているのですが、他の方法があったら教えて頂きたいです

## スクリーンショット

| before | after |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/55890106/150490221-ca509e8c-beed-495e-889b-c01af4d6923a.png" width="400px"> | <img src="https://user-images.githubusercontent.com/55890106/157998597-fa47ba4a-8e31-4013-91de-9d42a0006545.png" width="400px">