### PR TITLE
検索画面からお気に入り追加削除、お気に入りリスト画面から削除の処理を実装

### DIFF
--- a/CTAProject/Model/API/RealmRepository.swift
+++ b/CTAProject/Model/API/RealmRepository.swift
@@ -1,0 +1,69 @@
+//
+//  RealmManager.swift
+//  CTAProject
+//
+//  Created by Taisei Sakamoto on 2022/03/12.
+//
+
+import Foundation
+import RealmSwift
+import RxRealm
+import RxSwift
+
+protocol RealmRepositoryType {
+    /// 全ての要素を取得する
+    func get<O: Object>(type: O.Type) -> Observable<[O]>
+    /// 全ての要素をArray型で取得する
+    func getArray<O: Object>(type: O.Type) -> Array<O>
+    /// お気に入りリストに保存する
+    func add<O: Object>(object: O)
+    /// お気に入りリストから削除する
+    func delete<O: Object>(type: O.Type, id: String)
+}
+
+final class RealmRepository: RealmRepositoryType {
+
+    private let disposeBag: DisposeBag
+
+    init() {
+        self.disposeBag = DisposeBag()
+    }
+
+    func get<O: Object>(type: O.Type) -> Observable<[O]> {
+        do {
+            let realm = try Realm()
+            let objects = realm.objects(type).toArray()
+            return .just(objects)
+        } catch _ {
+            return .just([])
+        }
+    }
+    
+    func getArray<O: Object>(type: O.Type) -> Array<O> {
+        let realm = try! Realm()
+        return realm.objects(type.self).toArray()
+    }
+
+    func add<O: Object>(object: O) {
+        do {
+            let realm = try Realm()
+            Observable.from(object: object)
+                .subscribe(realm.rx.add(update: .modified))
+                .disposed(by: disposeBag)
+        } catch let error {
+            print("DEBUG: Error occurred.", error)
+        }
+    }
+    
+    func delete<O: Object>(type: O.Type, id: String) {
+        do {
+            let realm = try Realm()
+            let object = realm.objects(type.self).filter("id == '\(id)'")
+            try realm.write {
+                realm.delete(object)
+            }
+        } catch let error {
+            print("DEBUG: Error occurred.", error)
+        }
+    }
+}

--- a/CTAProject/Model/Entity/FavoriteShop.swift
+++ b/CTAProject/Model/Entity/FavoriteShop.swift
@@ -1,0 +1,29 @@
+//
+//  FavoriteShop.swift
+//  CTAProject
+//
+//  Created by Taisei Sakamoto on 2022/03/12.
+//
+
+import Foundation
+import RealmSwift
+
+final class FavoriteShop: Object {
+    @Persisted var name : String
+    @Persisted var budget: String
+    @Persisted var genre: String
+    @Persisted var station: String
+    @Persisted var logoImage: String
+
+    @Persisted(primaryKey: true) var id: String
+
+    convenience init(shop: Shop) {
+        self.init()
+        self.id = shop.id
+        self.name = shop.name
+        self.budget = shop.budget.name
+        self.genre = shop.genre?.name ?? ""
+        self.station = shop.stationName ?? ""
+        self.logoImage = "\(shop.logoImage)"
+    }
+}

--- a/CTAProject/Model/Entity/FavoriteShopDataSource.swift
+++ b/CTAProject/Model/Entity/FavoriteShopDataSource.swift
@@ -1,0 +1,22 @@
+//
+//  FavoriteShopDataSource.swift
+//  CTAProject
+//
+//  Created by Taisei Sakamoto on 2022/03/12.
+//
+
+import Foundation
+import RxDataSources
+
+struct FavoriteShopDataSource {
+    var items: [Item]
+}
+
+extension FavoriteShopDataSource: SectionModelType {
+    typealias Item = FavoriteShop
+
+    init(original: FavoriteShopDataSource, items: [FavoriteShop]) {
+        self = original
+        self.items = items
+    }
+}

--- a/CTAProject/Model/Entity/Shop.swift
+++ b/CTAProject/Model/Entity/Shop.swift
@@ -25,7 +25,7 @@ struct Shop: Decodable, Equatable {
 
     let id: String
     let name: String
-    let logoImage: URL?
+    let logoImage: URL
     let stationName: String?
     let genre: Genre?
     let budget: Budget

--- a/CTAProject/Model/Entity/ShopResponseDataSource.swift
+++ b/CTAProject/Model/Entity/ShopResponseDataSource.swift
@@ -8,14 +8,14 @@
 import Foundation
 import RxDataSources
 
-struct ShopResponseSectionModel {
+struct ShopResponseDataSource {
     var items: [Item]
 }
 
-extension ShopResponseSectionModel: SectionModelType {
+extension ShopResponseDataSource: SectionModelType {
     typealias Item = Shop
 
-    init(original: ShopResponseSectionModel, items: [Shop]) {
+    init(original: ShopResponseDataSource, items: [Shop]) {
         self = original
         self.items = items
     }

--- a/CTAProject/UIComponent/View/ShopTableViewCell.swift
+++ b/CTAProject/UIComponent/View/ShopTableViewCell.swift
@@ -88,7 +88,7 @@ final class ShopTableViewCell: UITableViewCell {
     // MARK: - Helpers
 
     private func updateFavoriteUI(isFavorite: Bool) {
-        let systemName = isFavorite ? "star.fill" : "star"
+        let systemName = isFavorite ? L10n.favoriteImageFill : L10n.favoriteImage
         let tintColor = isFavorite ? UIColor.orange : UIColor.systemGray
         favoriteButton.setImage(UIImage(systemName: systemName), for: .normal)
         favoriteButton.tintColor = tintColor

--- a/CTAProject/UIComponent/View/ShopTableViewCell.swift
+++ b/CTAProject/UIComponent/View/ShopTableViewCell.swift
@@ -46,52 +46,62 @@ final class ShopTableViewCell: UITableViewCell {
         return label
     }()
 
-    private let favoriteButton: UIButton = {
+    let favoriteButton: UIButton = {
         let button = UIButton(type: .system)
-        button.setImage(UIImage(systemName: "star"), for: .normal)
+        button.setImage(UIImage(systemName: L10n.favoriteImage), for: .normal)
         button.tintColor = .systemGray
+        button.tag = 1
         return button
     }()
 
-    private var dependency: Dependency!
-    private var disposeBag = DisposeBag()
+    private (set) var disposeBag = DisposeBag()
 
     // MARK: - Lifecycle
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        let viewStream = Dependency().viewStream
         configureUI()
-
-        favoriteButton.rx.tap
-            .subscribe(onNext: { _ in
-                viewStream.input.favoriteButtonTapped.onNext(())
-            })
-            .disposed(by: disposeBag)
-
-        viewStream.output.favoriteState
-            .withUnretained(self)
-            .subscribe(onNext: { me, isFavorite in
-                me.updateFavoriteUI(isFavorite: isFavorite)
-            }).disposed(by: disposeBag)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        disposeBag = DisposeBag()
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
         addSubview(favoriteButton)
-    }
+    } 
 
     // MARK: - Helpers
 
-    private func updateFavoriteUI(isFavorite: Bool) {
-        let systemName = isFavorite ? L10n.favoriteImageFill : L10n.favoriteImage
-        let tintColor = isFavorite ? UIColor.orange : UIColor.systemGray
-        favoriteButton.setImage(UIImage(systemName: systemName), for: .normal)
-        favoriteButton.tintColor = tintColor
+    func updateFavoriteUI() {
+        if favoriteButton.tag == 0 {
+            favoriteButton.setImage(UIImage(systemName: L10n.favoriteImageFill), for: .normal)
+            favoriteButton.tintColor = .orange
+            favoriteButton.tag = 1
+        } else {
+            favoriteButton.setImage(UIImage(systemName: L10n.favoriteImage), for: .normal)
+            favoriteButton.tintColor = .systemGray
+            favoriteButton.tag = 0
+        }
+    }
+    
+    private func CheckFavorite(item: Shop) {
+        let objectId = RealmRepository().getArray(type: FavoriteShop.self).map { $0.id }
+        if objectId.contains(item.id) {
+            favoriteButton.setImage(UIImage(systemName: L10n.favoriteImageFill), for: .normal)
+            favoriteButton.tintColor = .orange
+            favoriteButton.tag = 1
+        } else {
+            favoriteButton.setImage(UIImage(systemName: L10n.favoriteImage), for: .normal)
+            favoriteButton.tintColor = .systemGray
+            favoriteButton.tag = 0
+        }
     }
 
     private func configureUI() {
@@ -113,23 +123,22 @@ final class ShopTableViewCell: UITableViewCell {
         stack.centerY(inView: self)
         stack.anchor(left: shopImageView.rightAnchor, right: favoriteButton.leftAnchor, paddingLeft: 20, paddingRight: 12)
     }
-
-    func setupData(item: Shop) {
+  
+    func setupSearchData(item: Shop) {
         shopImageView.kf.setImage(with: item.logoImage)
         shopNameLabel.text = item.name
         budgetLabel.text = item.budget.name
         shopDetailLabel.text = L10n.shopDetailText(item.genre?.name ?? "", item.stationName ?? "")
+        
+        CheckFavorite(item: item)
     }
-}
 
-// MARK: - Dependency Injection
-
-extension ShopTableViewCell {
-    struct Dependency {
-        let viewStream: ListViewStreamType
-
-        init(viewStream: ListViewStreamType = ListViewStream()) {
-            self.viewStream = viewStream
-        }
+    func setupFavoriteData(item: FavoriteShop) {
+        shopImageView.kf.setImage(with: URL(string: item.logoImage))
+        shopNameLabel.text = item.name
+        budgetLabel.text = item.budget
+        shopDetailLabel.text = L10n.shopDetailText(item.genre, item.station)
+        favoriteButton.setImage(UIImage(systemName: L10n.favoriteImageFill), for: .normal)
+        favoriteButton.tintColor = .orange
     }
 }

--- a/CTAProject/UIComponent/ViewController/FavoriteViewController.swift
+++ b/CTAProject/UIComponent/ViewController/FavoriteViewController.swift
@@ -5,24 +5,93 @@
 //  Created by Taisei Sakamoto on 2022/01/12.
 //
 
+import RealmSwift
+import RxCocoa
+import RxDataSources
+import RxRealm
+import RxSwift
 import UIKit
+import PKHUD
 
 final class FavoriteViewController: UIViewController {
 
     // MARK: - Properties
 
+    private let viewStream: FavoriteViewStreamType
+
+    private let tableView = UITableView()
+    private var dataSource: RxTableViewSectionedReloadDataSource<FavoriteShopDataSource>?
+
+    private let disposeBag = DisposeBag()
+
     // MARK: - Lifecycle
+
+    init(viewStream: FavoriteViewStreamType = FavoriteViewStream()) {
+        self.viewStream = viewStream
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         configureNavigationBar(withTitle: L10n.navigationBarTitle)
-        configureUI()
+        configureTableView()
+        
+        guard let dataSource = dataSource else { return }
+        viewStream.output.dataSource
+            .bind(to: tableView.rx.items(dataSource: dataSource))
+            .disposed(by: disposeBag)
+        
+        viewStream.output.hud
+            .subscribe(onNext: { type in
+                HUD.show(type)
+            }).disposed(by: disposeBag)
+        
+        viewStream.output.hide
+            .subscribe(onNext: { _ in
+                HUD.hide()
+            }).disposed(by: disposeBag)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewStream.input.load.onNext(())
     }
 
     // MARK: - Helpers
 
-    private func configureUI() {
-        view.backgroundColor = .systemGray6
-        // TODO: - ここにUIコードを書いていく
+    private func configureTableView() { 
+        tableView.backgroundColor = .systemGray6
+        view.addSubview(tableView)
+        tableView.fillSuperView()
+
+        tableView.rowHeight = Const.TableView.height
+        tableView.register(cellType: ShopTableViewCell.self)
+
+        dataSource =
+            RxTableViewSectionedReloadDataSource<FavoriteShopDataSource>(configureCell: { [weak self] _, tableView, indexPath, item in
+                guard let me = self else { return UITableViewCell() }
+                let cell = tableView.dequeueReusableCell(for: indexPath, cellType: ShopTableViewCell.self)
+                cell.setupFavoriteData(item: item)
+                
+                cell.favoriteButton.rx.tap
+                    .subscribe(onNext: { _ in
+                        me.viewStream.input.deleteFavorite.onNext(item.id)
+                    }).disposed(by: cell.disposeBag)
+                return cell
+            })
+    }
+}
+
+// MARK: - Private Const
+
+extension FavoriteViewController {
+    private enum Const {
+        enum TableView {
+            static let height = CGFloat(100)
+        }
     }
 }

--- a/CTAProject/UIComponent/ViewController/ListViewController.swift
+++ b/CTAProject/UIComponent/ViewController/ListViewController.swift
@@ -102,6 +102,20 @@ final class ListViewController: UIViewController {
         RxTableViewSectionedReloadDataSource<ShopResponseDataSource>(configureCell: { [weak self] _, tableView, indexPath, item in
             guard let me = self else { return UITableViewCell() }
             let cell = tableView.dequeueReusableCell(for: indexPath, cellType: ShopTableViewCell.self)
+            cell.setupSearchData(item: item)
+            
+            cell.favoriteButton.rx.tap
+                .subscribe(onNext: { _ in
+                    if cell.favoriteButton.tag == 0 {
+                        me.viewStream.input.addFavorite.onNext(item)
+                    } else {
+                        me.viewStream.input.deleteFavorite.onNext(item.id)
+                    }
+                    cell.updateFavoriteUI()
+                }).disposed(by: cell.disposeBag)
+            
+            return cell
+        })
     }
 
     private func configureUI() {

--- a/CTAProject/UIComponent/ViewController/ListViewController.swift
+++ b/CTAProject/UIComponent/ViewController/ListViewController.swift
@@ -19,7 +19,7 @@ final class ListViewController: UIViewController {
     private let searchBar = UISearchBar()
 
     private let viewStream: ListViewStreamType
-    private var dataSource: RxTableViewSectionedReloadDataSource<ShopResponseSectionModel>?
+    private var dataSource: RxTableViewSectionedReloadDataSource<ShopResponseDataSource>?
 
     private let disposeBag = DisposeBag()
 
@@ -93,17 +93,15 @@ final class ListViewController: UIViewController {
         searchBar.placeholder = L10n.searchBarPlaceholder
         searchBar.backgroundColor = UIColor.CTA.searchBarBackground
     }
-
+    
     private func configureTableView() {
         tableView.rowHeight = Const.TableView.height
         tableView.register(cellType: ShopTableViewCell.self)
-
+        
         dataSource =
-            RxTableViewSectionedReloadDataSource<ShopResponseSectionModel>(configureCell: { _, tableView, indexPath, item in
-                let cell = tableView.dequeueReusableCell(for: indexPath, cellType: ShopTableViewCell.self)
-                cell.setupData(item: item)
-                return cell
-            })
+        RxTableViewSectionedReloadDataSource<ShopResponseDataSource>(configureCell: { [weak self] _, tableView, indexPath, item in
+            guard let me = self else { return UITableViewCell() }
+            let cell = tableView.dequeueReusableCell(for: indexPath, cellType: ShopTableViewCell.self)
     }
 
     private func configureUI() {

--- a/CTAProject/UILogic/ViewModel/FavoriteViewModel.swift
+++ b/CTAProject/UILogic/ViewModel/FavoriteViewModel.swift
@@ -1,0 +1,96 @@
+//
+//  FavoriteViewModel.swift
+//  CTAProject
+//
+//  Created by Taisei Sakamoto on 2022/03/19.
+//
+
+import Foundation
+import RxCocoa
+import RxDataSources
+import RxSwift
+import Unio
+import PKHUD
+
+final class FavoriteViewStream: UnioStream<FavoriteViewStream>, FavoriteViewStreamType {
+
+    // MARK: - Initializer
+
+    convenience init(realmManager: RealmRepositoryType = RealmRepository()) {
+        self.init(input: Input(), state: State(), extra: Extra(realmManager: realmManager))
+    }
+
+    static func bind(from dependency: Dependency<Input, State, Extra>, disposeBag: DisposeBag) -> Output {
+        let input = dependency.inputObservables
+        let state = dependency.state
+        let extra = dependency.extra
+
+        // MARK: - inputs
+
+        input.load
+            .flatMapLatest({ () -> Observable<[FavoriteShop]> in
+                return extra.realmManager.get(type: FavoriteShop.self)
+            })
+            .subscribe(onNext: { objects in
+                state.dataSource.accept([.init(items: objects)])
+            }).disposed(by: disposeBag)
+        
+        input.deleteFavorite
+            .subscribe(onNext: { id in
+                state.hud.accept(.success)
+                extra.realmManager.delete(type: FavoriteShop.self, id: id)
+                let object = extra.realmManager.getArray(type: FavoriteShop.self)
+                let dataSources = [FavoriteShopDataSource(items: object)]
+                state.dataSource.accept(dataSources)
+            }).disposed(by: disposeBag)
+        
+        // MARK: Outputs
+        
+        state.hud
+            .filter { $0 == .error || $0 == .success }
+            .delay(.milliseconds(700), scheduler: ConcurrentMainScheduler.instance)
+            .subscribe(onNext: { _ in
+                state.hide.accept(())
+            }).disposed(by: disposeBag)
+
+        return Output(dataSource: state.dataSource.asObservable(), hud: state.hud.asObservable(),
+                      hide: state.hide.asObservable())
+    }
+}
+
+extension FavoriteViewStream {
+
+    // MARK: - Input
+
+    struct Input: InputType {
+        let load = PublishRelay<Void>()
+        let favoriteButtonTapped = PublishRelay<Void>()
+        let deleteFavorite = PublishRelay<String>()
+    }
+
+    // MARK: - Output
+
+    struct Output: OutputType {
+        let dataSource: Observable<[FavoriteShopDataSource]>
+        let hud: Observable<HUDContentType>
+        let hide: Observable<Void>
+    }
+
+    // MARK: - State
+
+    struct State: StateType {
+        let dataSource = BehaviorRelay<[FavoriteShopDataSource]>(value: [])
+        let hud = PublishRelay<HUDContentType>()
+        let hide = PublishRelay<Void>()
+    }
+
+    // MARK: - Extra
+
+    struct Extra: ExtraType {
+        let realmManager: RealmRepositoryType
+
+        init(realmManager: RealmRepositoryType) {
+            self.realmManager = realmManager
+        }
+    }
+}

--- a/CTAProject/UILogicInterface/FavoriteViewModelType.swift
+++ b/CTAProject/UILogicInterface/FavoriteViewModelType.swift
@@ -1,0 +1,14 @@
+//
+//  FavoriteViewModelType.swift
+//  CTAProject
+//
+//  Created by Taisei Sakamoto on 2022/03/19.
+//
+
+import Foundation
+import Unio
+
+protocol FavoriteViewStreamType: AnyObject {
+    var input: InputWrapper<FavoriteViewStream.Input> { get }
+    var output: OutputWrapper<FavoriteViewStream.Output> { get }
+}

--- a/CTAProject/UIResource/Generated/Localized.swift
+++ b/CTAProject/UIResource/Generated/Localized.swift
@@ -13,6 +13,10 @@ public enum L10n {
   public static let characterAlertMesssage = L10n.tr("Localizable", "characterAlertMesssage")
   /// 閉じる
   public static let closeButtonTitle = L10n.tr("Localizable", "closeButtonTitle")
+  /// star
+  public static let favoriteImage = L10n.tr("Localizable", "favoriteImage")
+  /// star.fill
+  public static let favoriteImageFill = L10n.tr("Localizable", "favoriteImageFill")
   /// お気に入り
   public static let favoriteTabBarTitle = L10n.tr("Localizable", "favoriteTabBarTitle")
   /// リスト

--- a/CTAProject/UIResource/Resource/Localizable/Localizable.strings
+++ b/CTAProject/UIResource/Resource/Localizable/Localizable.strings
@@ -7,3 +7,5 @@
 "characterAlertMesssage" = "文字数が50文字を超過しています。";
 "closeButtonTitle" = "閉じる";
 "shopDetailText" = "%@ / %@駅";
+"favoriteImage" = "star";
+"favoriteImageFill" = "star.fill";

--- a/CTAProjectTests/Utils/Mock.swift
+++ b/CTAProjectTests/Utils/Mock.swift
@@ -28,7 +28,7 @@ enum TestMockData {
 extension TestMockData {
 
     static let mockText = "mock text"
-    static let url = URL(string: "https://mock.png")
+    static let url = URL(string: "https://mock.png")!
     static let genre = Genre(name: mockText)
     static let budget = Budget(name: mockText)
 

--- a/Podfile
+++ b/Podfile
@@ -12,6 +12,8 @@ target 'CTAProject' do
   pod 'RxCocoa'
   pod 'Moya/RxSwift', '~> 15.0'
   pod 'RxDataSources', '~> 5.0'
+  pod 'RealmSwift', '~>10'
+  pod 'RxRealm'
 
   # Pods for CTAProject
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,18 @@
 PODS:
   - Alamofire (5.5.0)
   - Differentiator (5.0.0)
-  - Kingfisher (7.1.2)
+  - Kingfisher (7.2.0)
   - Moya/Core (15.0.0):
     - Alamofire (~> 5.0)
   - Moya/RxSwift (15.0.0):
     - Moya/Core
     - RxSwift (~> 6.0)
   - PKHUD (5.3.0)
+  - Realm (10.24.2):
+    - Realm/Headers (= 10.24.2)
+  - Realm/Headers (10.24.2)
+  - RealmSwift (10.24.2):
+    - Realm (= 10.24.2)
   - RxCocoa (6.5.0):
     - RxRelay (= 6.5.0)
     - RxSwift (= 6.5.0)
@@ -15,13 +20,18 @@ PODS:
     - Differentiator (~> 5.0)
     - RxCocoa (~> 6.0)
     - RxSwift (~> 6.0)
+  - RxRealm (5.0.4):
+    - Realm (~> 10.21)
+    - RealmSwift (~> 10.21)
+    - RxCocoa (~> 6.1)
+    - RxSwift (~> 6.1)
   - RxRelay (6.5.0):
     - RxSwift (= 6.5.0)
   - RxSwift (6.5.0)
   - RxTest (6.5.0):
     - RxSwift (= 6.5.0)
   - SwiftGen (6.5.1)
-  - SwiftLint (0.46.2)
+  - SwiftLint (0.46.5)
   - Unio (0.11.0):
     - RxRelay (~> 6.0)
     - RxSwift (~> 6.0)
@@ -30,8 +40,10 @@ DEPENDENCIES:
   - Kingfisher (~> 7.0)
   - Moya/RxSwift (~> 15.0)
   - PKHUD
+  - RealmSwift (~> 10)
   - RxCocoa
   - RxDataSources (~> 5.0)
+  - RxRealm
   - RxTest
   - SwiftGen
   - SwiftLint
@@ -44,8 +56,11 @@ SPEC REPOS:
     - Kingfisher
     - Moya
     - PKHUD
+    - Realm
+    - RealmSwift
     - RxCocoa
     - RxDataSources
+    - RxRealm
     - RxRelay
     - RxSwift
     - RxTest
@@ -56,18 +71,21 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   Alamofire: 1c4fb5369c3fe93d2857c780d8bbe09f06f97e7c
   Differentiator: e8497ceab83c1b10ca233716d547b9af21b9344d
-  Kingfisher: 44ed6a8504763f27bab46163adfac83f5deb240c
+  Kingfisher: 3ac0b75b155cabc0e544877d1a4deea29feece92
   Moya: 138f0573e53411fb3dc17016add0b748dfbd78ee
   PKHUD: 98f3e4bc904b9c916f1c5bb6d765365b5357291b
+  Realm: c8421eee9ff92b16b4f91a313b5cc695c37c1921
+  RealmSwift: 10ed6fa09c36aaaff55e12afdc71802ec3ddb1c0
   RxCocoa: 94f817b71c07517321eb4f9ad299112ca8af743b
   RxDataSources: aa47cc1ed6c500fa0dfecac5c979b723542d79cf
+  RxRealm: 666c8785327fe2fff972a3093b35dc7055c1ca38
   RxRelay: 1de1523e604c72b6c68feadedd1af3b1b4d0ecbd
   RxSwift: 5710a9e6b17f3c3d6e40d6e559b9fa1e813b2ef8
   RxTest: eb2d23adefc5a5ebf5779c7792fa3edfe6ebcc17
   SwiftGen: a6d22010845f08fe18fbdf3a07a8e380fd22e0ea
-  SwiftLint: 6bc52a21f0fd44cab9aa2dc8e534fb9f5e3ec507
+  SwiftLint: 2c16e8fa99dac2e440dc0c70ea74d2532048f6cf
   Unio: 6e57bd33dbcf38d281b0b420f75c0eae3bef0cf3
 
-PODFILE CHECKSUM: 9fcda85e90ca4489c7a81df326ffdff92d5036e0
+PODFILE CHECKSUM: 726f3092e54d6829f5a530195fd28963c9f44123
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3


### PR DESCRIPTION
## 関連URL

[タスク2](https://github.com/sosuiiii/CTAProject2022/issues/3)に関する実装

## 前提

・検索→お気に入り追加、削除を実装
・お気に入りリスト→削除→画面更新まで実装

## 仕様

・RealmSwiftを使った実装
・RxSwiftを使ったコーディング

## 対応内容

- [x] 検索画面からお気に入りボタンのタップ検知→リストに追加or削除→UI更新
- [x] お気に入りリスト画面から登録削除→tableView更新
 
### 実装機能1

4b3f14a0cc4882b28fa72e67bfbf3782d3c007c2: FavoriteShopファイルの追加
80ed9e90d0be56ba8a995e4f70674cda4a8c028e: FavoriteShopDataSouceファイルの追加
14592f7b380e0cb18f1ab0cdc50cd2bdb80ade37: RealmRepositoryファイルの追加
889a0e7c01d9f7a1ab0ce0aa234b420e578d57f4: FavoriteVMファイルの追加
2af831cbb0e32b02a18a710bd9e0c71b8fc68900: ListVMのアップデート（add, deleteイベントの実装）
2e2943bbecc297ececf7bfcf993ba93bc10cdffa: ListVCのアップデート（tapイベントをViewModelに送る）
00c4768f03dd47d69c5eb0f4cfca386f00181c7a: ShopTableViewCellのアップデート（ボタンにtagをつける、UIを更新するメソッド、すでにお気に入りされているかチェックするメソッドを実装）
0030672042760916a2271cba2679c36ad880d5e7: FavoriteVCのファイルの追加


## レビュー観点

・Rxが適切に使えているか
・イベントの流れが適切か

## スクリーンショット

| | |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/55890106/160087810-a1cb9b1d-ed8e-4c31-bb7f-4108e69e111f.png" width="400px"> | <img src="https://user-images.githubusercontent.com/55890106/160087898-a96bf485-90e1-493a-b9bd-447472253ae6.png" width="400px">